### PR TITLE
Fix: [release-docs] name the source docs just '-docs.tar.xz'

### DIFF
--- a/release-docs/files/run.sh
+++ b/release-docs/files/run.sh
@@ -24,11 +24,11 @@ doxygen
     doxygen Doxyfile_Game
 )
 
-mv docs/source ${BASENAME}-docs-source
+mv docs/source ${BASENAME}-docs
 mv docs/aidocs ${BASENAME}-docs-ai
 mv docs/gamedocs ${BASENAME}-docs-gs
 
 mkdir -p bundles
-tar --xz -cf bundles/${BASENAME}-docs-source.tar.xz ${BASENAME}-docs-source
+tar --xz -cf bundles/${BASENAME}-docs.tar.xz ${BASENAME}-docs
 tar --xz -cf bundles/${BASENAME}-docs-ai.tar.xz ${BASENAME}-docs-ai
 tar --xz -cf bundles/${BASENAME}-docs-gs.tar.xz ${BASENAME}-docs-gs


### PR DESCRIPTION
Otherwise we have -docs-source.tar.xz and -source.tar.xz in a
release build. This makes a lot of scripting tricky, as locating
the source tarball becomes a lot more difficult.