### PR TITLE
Change: Remove subversion and mercurial from base docker image

### DIFF
--- a/base-linux/Dockerfile
+++ b/base-linux/Dockerfile
@@ -29,9 +29,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && \
     libsdl1.2-dev \
     libxdg-basedir-dev \
     make \
-    mercurial \
     software-properties-common \
-    subversion \
     tar \
     wget \
     xz-utils \


### PR DESCRIPTION
So.. of course close this if these really are necessary. But as far as I know subversion and mercurial aren't necessary in order to build OpenTTD.