### PR TITLE
Fix: CMake 'make test' does not run 'make all'. Make this explicit.

### DIFF
--- a/ci-linux-amd64-clang-3.8/files/run.sh
+++ b/ci-linux-amd64-clang-3.8/files/run.sh
@@ -17,4 +17,4 @@ else
     ./configure --prefix-dir=/usr
 fi
 
-make -j2 test
+make -j2 all test

--- a/ci-linux-amd64-gcc-6/files/run.sh
+++ b/ci-linux-amd64-gcc-6/files/run.sh
@@ -17,4 +17,4 @@ else
     ./configure --prefix-dir=/usr
 fi
 
-make -j2 test
+make -j2 all test

--- a/ci-linux-i386-gcc-6/files/run.sh
+++ b/ci-linux-i386-gcc-6/files/run.sh
@@ -17,4 +17,4 @@ else
     ./configure --prefix-dir=/usr
 fi
 
-make -j2 test
+make -j2 all test


### PR DESCRIPTION
This is a long outstanding bug in CMake, with no resolution. To
safe all of us a huge headache, simply run 'make all test' instead.