### PR TITLE
Add: support CMake for release builds too

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -19,12 +19,6 @@ jobs:
 
   strategy:
     matrix:
-      linux-debian-jessie-i386:
-        Distro: i386/debian
-        Release: jessie-slim
-      linux-debian-jessie-amd64:
-        Distro: debian
-        Release: jessie-slim
       linux-debian-stretch-i386:
         Distro: i386/debian
         Release: stretch-slim
@@ -131,14 +125,6 @@ jobs:
 
   strategy:
     matrix:
-        linux-debian-jessie-i386-gcc:
-          Distro: debian
-          Release: jessie
-          Arch: i386
-        linux-debian-jessie-amd64-gcc:
-          Distro: debian
-          Release: jessie
-          Arch: amd64
         linux-debian-stretch-i386-gcc:
           Distro: debian
           Release: stretch

--- a/release-linux-deb-gcc/files/run.sh
+++ b/release-linux-deb-gcc/files/run.sh
@@ -20,7 +20,15 @@ echo "  Release: ${RELEASE}"
 echo "  Arch: ${ARCH}"
 echo ""
 
-ln -sf os/debian debian && mkdir -p bundles
-fakeroot make -j2 -f debian/rules binary
-mv ../*dbg*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}-dbg.deb
-mv ../*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}.deb
+if [ -e "CMakeLists.txt" ]; then
+    mkdir build
+    cd build
+    cmake ..
+    make -j2 package
+    mv bundles/*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}.deb
+else
+    ln -sf os/debian debian && mkdir -p bundles
+    fakeroot make -j2 -f debian/rules binary
+    mv ../*dbg*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}-dbg.deb
+    mv ../*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}.deb
+fi

--- a/release-linux-generic-gcc/files/run.sh
+++ b/release-linux-generic-gcc/files/run.sh
@@ -18,7 +18,14 @@ echo "  Compiler: GCC"
 echo "  Arch: ${ARCH}"
 echo ""
 
-mkdir -p bundles
-./configure --static-icu --without-xdg-basedir --prefix-dir=/usr
-make -j2
-make bundle_gzip bundle_xz BUNDLE_NAME=${BASENAME}-linux-generic-${ARCH}
+if [ -e "CMakeLists.txt" ]; then
+    mkdir build
+    cd build
+    cmake ..
+    make -j2 package
+else
+    mkdir -p bundles
+    ./configure --static-icu --without-xdg-basedir --prefix-dir=/usr
+    make -j2
+    make bundle_gzip bundle_xz BUNDLE_NAME=${BASENAME}-linux-generic-${ARCH}
+fi


### PR DESCRIPTION
This sadly means we can no longer support Debian jessie, as its CMake is too old (3.0, we need at least 3.5).