### PR TITLE
Fix: put docs also in build/bundles with CMake sources

### DIFF
--- a/release-docs/files/run.sh
+++ b/release-docs/files/run.sh
@@ -28,6 +28,13 @@ mv docs/source ${BASENAME}-docs
 mv docs/aidocs ${BASENAME}-docs-ai
 mv docs/gamedocs ${BASENAME}-docs-gs
 
+# To be consistent with other docker, put the result in the build folder
+# when CMake is used.
+if [ -e "CMakeLists.txt" ]; then
+    mkdir -p build
+    cd build
+fi
+
 mkdir -p bundles
 tar --xz -cf bundles/${BASENAME}-docs.tar.xz ${BASENAME}-docs
 tar --xz -cf bundles/${BASENAME}-docs-ai.tar.xz ${BASENAME}-docs-ai


### PR DESCRIPTION
This is still a bit odd; Doxygen still compiles in-source, which
is wrong. But this is something for another day.