### PR TITLE
Add: clang-3.9 Docker image

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -84,6 +84,9 @@ jobs:
       linux-amd64-clang-3.8:
         Folder: ci-linux-amd64-clang-3.8
         Tag: linux-amd64-clang-3.8
+      linux-amd64-clang-3.9:
+        Folder: ci-linux-amd64-clang-3.9
+        Tag: linux-amd64-clang-3.9
       linux-amd64-gcc-6:
         Folder: ci-linux-amd64-gcc-6
         Tag: linux-amd64-gcc-6

--- a/ci-linux-amd64-clang-3.9/Dockerfile
+++ b/ci-linux-amd64-clang-3.9/Dockerfile
@@ -1,0 +1,18 @@
+FROM openttd/base:linux-debian-stretch-amd64
+
+RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    clang-3.9=1:3.9* \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install openttd-opengfx, so we can easier run the regression tests
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openttd-opengfx \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY files/run.sh /usr/bin/
+
+WORKDIR /workdir/source
+
+ENTRYPOINT ["run.sh"]
+CMD []

--- a/ci-linux-amd64-clang-3.9/files/run.sh
+++ b/ci-linux-amd64-clang-3.9/files/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+echo ""
+echo "Validating source"
+echo "  OS: Linux"
+echo "  Compiler: clang 3.9"
+echo "  Arch: amd64"
+echo ""
+
+if [ -e "CMakeLists.txt" ]; then
+    mkdir build
+    cd build
+    cmake ..
+else
+    ./configure --prefix-dir=/usr
+fi
+
+make -j2 all test


### PR DESCRIPTION
clang-3.8 is proving slightly too old (OpenTTD/OpenTTD#7630), so add a slightly newer version

I'm not sure whether there will be some issue with the clang-3.9 package only providing /usr/bin/clang-3.9 - I don't know if it /usr/bin/clang will get created and/or picked up by the configure script

If nothing else, we can define it in run.sh while configuring