### PR TITLE
Fix: Define specific compilers to use for clang-3.9 Docker image

### DIFF
--- a/ci-linux-amd64-clang-3.9/files/run.sh
+++ b/ci-linux-amd64-clang-3.9/files/run.sh
@@ -9,6 +9,8 @@ echo "  Compiler: clang 3.9"
 echo "  Arch: amd64"
 echo ""
 
+export CC=clang-3.9
+export CXX=clang++-3.9
 if [ -e "CMakeLists.txt" ]; then
     mkdir build
     cd build


### PR DESCRIPTION
It'll probably work this time.