### PR TITLE
Fix: workaround a bug in a Debian patch for Doxygen

### DIFF
--- a/release-docs/files/run.sh
+++ b/release-docs/files/run.sh
@@ -24,6 +24,11 @@ VERSION=${VERSION} doxygen
     VERSION=${VERSION} doxygen Doxyfile_Game
 )
 
+# Fixing a bug in a Debian patch on Doxygen
+# https://bugs.launchpad.net/ubuntu/+source/doxygen/+bug/1631169
+cp docs/source/html/dynsections.js docs/aidocs/html/
+cp docs/source/html/dynsections.js docs/gamedocs/html/
+
 mv docs/source ${BASENAME}-docs
 mv docs/aidocs ${BASENAME}-docs-ai
 mv docs/gamedocs ${BASENAME}-docs-gs


### PR DESCRIPTION
Yes. One of the Debian maintainers introduced a patch, that worked
well in 2016. Because of fuzzy-applying of patches, it drifted from
the intended line of code, and is now doing something completely
wrong. For more information, see:

https://bugs.launchpad.net/ubuntu/+source/doxygen/+bug/1631169

There has been some pointing fingers, but no fix as of yet.