### PR TITLE
Fix 091287d: [release-docs] cmake requires a compiler

### DIFF
--- a/release-docs/Dockerfile
+++ b/release-docs/Dockerfile
@@ -4,6 +4,7 @@ FROM openttd/base:linux-debian-stretch-amd64
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends \
     \
+    clang-3.9=1:3.9* \
     doxygen \
     gawk \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Of course I needed a nightly build failure to find this. I opted for clang, because it's only 1 package (vs 3 for gcc/g++/binutils).