### PR TITLE
Fix 3775a12: [release-docs] use default clang

### DIFF
--- a/release-docs/Dockerfile
+++ b/release-docs/Dockerfile
@@ -4,7 +4,7 @@ FROM openttd/base:linux-debian-stretch-amd64
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends \
     \
-    clang-3.9=1:3.9* \
+    clang \
     doxygen \
     gawk \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`clang-3.9` needs CXX and CC to be defined (see #38). `clang` should just work (at least I see nothing special for it in its image run.sh)